### PR TITLE
Download links now lead to device-specific pages

### DIFF
--- a/src/com/android/settings/bliss/Download.java
+++ b/src/com/android/settings/bliss/Download.java
@@ -96,12 +96,12 @@ public class Download extends SettingsPreferenceFragment implements OnPreference
             startActivity(intent);
             return true;
         } else if (preference == mBlissOfficial) {
-            Uri uri = Uri.parse("http://downloads.blissroms.com/BlissPop/Official/");
+            Uri uri = Uri.parse("http://downloads.blissroms.com/BlissPop/Official/"+Build.DEVICE);
             Intent intent = new Intent(Intent.ACTION_VIEW, uri);
             startActivity(intent);
             return true;
         } else if (preference == mBlissNightly) {
-            Uri uri = Uri.parse("http://downloads.blissroms.com/BlissPop/Nightlies/");
+            Uri uri = Uri.parse("http://downloads.blissroms.com/BlissPop/Nightlies/"+Build.DEVICE);
             Intent intent = new Intent(Intent.ACTION_VIEW, uri);
             startActivity(intent);
             return true;


### PR DESCRIPTION
Just added a simple Build.DEVICE to add the device codename at the end of the download URIs, so that the user gets directly to the download page for his specific device.
